### PR TITLE
Laravel 5.4 Support

### DIFF
--- a/src/Reportico/Reportico/ReporticoServiceProvider.php
+++ b/src/Reportico/Reportico/ReporticoServiceProvider.php
@@ -127,7 +127,7 @@ class ReporticoServiceProvider extends ServiceProvider {
 	{
         $app = $this->app;
 
-        $this->app['getReporticoEngine'] = $this->app->share(function($app)
+        $this->app->singleton('getReporticoEngine', function($app)
         {
             $this->engine = new reportico();
 


### PR DESCRIPTION
https://laravel.com/docs/5.4/upgrade

As of Laravel 5.4, there is no more share method. Updated to singleton.